### PR TITLE
Remove tl expected v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,80 +7,95 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-linux:
-    runs-on: ubuntu-latest
+  build:
+    name: ${{ matrix.config.name }}
+    runs-on: ${{ matrix.config.os }}-${{ matrix.config.os-version }}
     strategy:
+      fail-fast: false
       matrix:
-        include:
-          - compiler-name: GCC 13
-            cc: gcc-13
-            cxx: g++-13
-            install-script: |
-              sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-              sudo apt update
-              sudo apt install -y g++-13
-            build-type: Debug
-          - compiler-name: GCC 13
-            cc: gcc-13
-            cxx: g++-13
-            install-script: |
-              sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-              sudo apt update
-              sudo apt install -y g++-13
-            build-type: Release
-          - compiler-name: Clang 17
-            cc: clang-17
-            cxx: clang++-17
-            install-script: |
-              wget https://apt.llvm.org/llvm.sh
-              chmod +x llvm.sh
-              sudo ./llvm.sh 17
-              sudo apt install libstdc++-12-dev
-            build-type: Debug
-          - compiler-name: Clang 17
-            cc: clang-17
-            cxx: clang++-17
-            install-script: |
-              wget https://apt.llvm.org/llvm.sh
-              chmod +x llvm.sh
-              sudo ./llvm.sh 17
-              sudo apt install libstdc++-12-dev
-            build-type: Release
+        config:
+          - name: Windows MSVC Release
+            os: windows
+            os-version: 2022
+            msvc: true
+            buildtype: Release
+
+          - name: Windows MSVC Debug
+            os: windows
+            os-version: 2022
+            msvc: true
+            buildtype: Debug
+  
+          - name: Linux GCC Release
+            os: ubuntu
+            os-version: 22.04
+            buildtype: Release
+            clang: false
+
+          - name: Linux GCC Debug
+            os: ubuntu
+            os-version: 22.04
+            buildtype: Debug
+            clang: false
+            
+          - name: Linux Clang Release
+            os: ubuntu
+            os-version: 22.04
+            buildtype: Release
+            clang: true
+
+          - name: Linux Clang Debug
+            os: ubuntu
+            os-version: 22.04
+            buildtype: Debug
+            clang: true
+
 
     steps:
-      - uses: actions/checkout@v3
-      - name: Install compiler (${{ matrix.compiler-name }})
+      - uses: actions/checkout@v4
+
+      - name: Setup MSVC (Windows)
+        if: matrix.config.os == 'windows' && matrix.config.msvc == true
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Install dependencies (Linux)
+        if: matrix.config.os == 'ubuntu'
         run: |
-          ${{ matrix.install-script }}
+          sudo apt-get update
+          sudo apt install curl pkg-config zip unzip tar cmake git -y
+  
+      - name: Install cmake >= 3.25 (Linux)
+        if: matrix.config.os == 'ubuntu'
+        run: |
+          sudo apt-get update
+          sudo apt-get install gpg wget
+          wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | sudo tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
+          echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ jammy main' | sudo tee /etc/apt/sources.list.d/kitware.list >/dev/null
+          sudo apt-get update
+          sudo apt-get install cmake -y
+
+      - name: Setup Clang (Linux)
+        if: matrix.config.os == 'ubuntu' && matrix.config.clang == true
+        uses: egor-tensin/setup-clang@v1
+        with:
+          version: 17
+          platform: x64
+
+      - name: Setup GCC (Linux)
+        if: matrix.config.os == 'ubuntu' && matrix.config.clang == false
+        uses: egor-tensin/setup-gcc@v1
+        with:
+          version: 13
+          platform: x64
+
+      - uses: abdes/gha-setup-ninja@master
+
       - name: Configure CMake
         run: |
-          sudo update-alternatives --install /usr/bin/cc cc /usr/bin/${{ matrix.cc }} 100
-          sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/${{ matrix.cxx }} 100
-          cmake -B build -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=${{ matrix.build-type }}
-      - name: Build
-        run: cmake --build build
-      - name: Run Tests
-        run: ctest --test-dir build --verbose
+          cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{ matrix.config.buildtype }} ${{github.workspace}} -G Ninja
 
-  build-windows:
-    runs-on: windows-latest
-    strategy:
-      matrix:
-        build-type: [ Debug, Release ]
-    steps:
-      - uses: actions/checkout@v3
-      - name: Install Ninja
-        run: choco install ninja
-      - name: Install CMake
-        run: choco install cmake --installargs 'ADD_CMAKE_TO_PATH=System'
-      - name: Set up Visual Studio Environment
-        uses: ilammy/msvc-dev-cmd@v1
-        with:
-          toolset: 14.30
-          arch: x64
-      - name: Configure CMake with Ninja and C++23
-        run: cmake -B build -G "Ninja" -DCMAKE_CXX_STANDARD=23 -DCMAKE_BUILD_TYPE=${{ matrix.build-type }}
-      - name: Build with Ninja
-        run: cmake --build build
+      - name: Build
+        run: cmake --build ${{github.workspace}}/build -j --config ${{ matrix.config.buildtype }}
+
       - name: Run Tests
-        run: ctest --test-dir build --verbose
+        run: ctest --test-dir ${{github.workspace}}/build --verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,21 +28,23 @@ jobs:
               sudo apt update
               sudo apt install -y g++-13
             build-type: Release
-          - compiler-name: Clang 16
-            cc: clang-16
-            cxx: clang++-16
+          - compiler-name: Clang 17
+            cc: clang-17
+            cxx: clang++-17
             install-script: |
               wget https://apt.llvm.org/llvm.sh
               chmod +x llvm.sh
-              sudo ./llvm.sh 16
+              sudo ./llvm.sh 17
+              sudo apt install libstdc++-12-dev
             build-type: Debug
-          - compiler-name: Clang 16
-            cc: clang-16
-            cxx: clang++-16
+          - compiler-name: Clang 17
+            cc: clang-17
+            cxx: clang++-17
             install-script: |
               wget https://apt.llvm.org/llvm.sh
               chmod +x llvm.sh
-              sudo ./llvm.sh 16
+              sudo ./llvm.sh 17
+              sudo apt install libstdc++-12-dev
             build-type: Release
 
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,10 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 include(${PROJECT_SOURCE_DIR}/project_options.cmake)
 include(${PROJECT_SOURCE_DIR}/dependencies.cmake)
 
+if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
+endif()
+
 c2k_sockets_setup_dependencies()
 
 add_subdirectory(src bin)

--- a/dependencies.cmake
+++ b/dependencies.cmake
@@ -11,14 +11,5 @@ function(c2k_sockets_setup_dependencies)
                 "BUILD_GMOCK OFF"
                 "INSTALL_GTEST OFF"
         )
-        CPMAddPackage(
-                NAME TL_EXPECTED
-                GITHUB_REPOSITORY TartanLlama/expected
-                VERSION 1.1.0
-                OPTIONS
-                "EXPECTED_BUILD_PACKAGE OFF"
-                "EXPECTED_BUILD_TESTS OFF"
-                "EXPECTED_BUILD_PACKAGE_DEB OFF"
-        )
     endif ()
 endfunction()

--- a/src/sockets/CMakeLists.txt
+++ b/src/sockets/CMakeLists.txt
@@ -24,4 +24,3 @@ if (WIN32)
 endif ()
 
 target_link_libraries(c2k_sockets PRIVATE ${SOCKET_LIBRARIES} c2k_sockets_options)
-target_link_system_libraries(c2k_sockets PUBLIC tl::expected)

--- a/src/sockets/include/sockets/detail/channel.hpp
+++ b/src/sockets/include/sockets/detail/channel.hpp
@@ -2,12 +2,12 @@
 
 #include <atomic>
 #include <cassert>
+#include <expected>
 #include <future>
 #include <memory>
 #include <mutex>
 #include <optional>
 #include <stdexcept>
-#include <expected>
 
 namespace c2k {
 

--- a/src/sockets/include/sockets/detail/channel.hpp
+++ b/src/sockets/include/sockets/detail/channel.hpp
@@ -7,7 +7,7 @@
 #include <mutex>
 #include <optional>
 #include <stdexcept>
-#include <tl/expected.hpp>
+#include <expected>
 
 namespace c2k {
 
@@ -96,13 +96,13 @@ namespace c2k {
             this->state()->condition_variable.notify_one();
         }
 
-        [[nodiscard]] tl::expected<void, T> try_send(T value) {
+        [[nodiscard]] std::expected<void, T> try_send(T value) {
             if (this->state() == nullptr) {
                 throw ChannelError{ "cannot call try_send() on a moved-from channel" };
             }
             auto lock = std::unique_lock{ this->state()->mutex };
             if (not this->state()->is_open or this->state()->value.has_value()) {
-                return tl::unexpected{ std::move(value) };
+                return std::unexpected{ std::move(value) };
             }
             assert(not this->state()->value.has_value());
             this->state()->value = std::move(value);
@@ -187,7 +187,7 @@ namespace c2k {
             m_sender.send(std::move(value));
         }
 
-        [[nodiscard]] tl::expected<void, T> try_send(T value) {
+        [[nodiscard]] std::expected<void, T> try_send(T value) {
             return m_sender.try_send(std::move(value));
         }
 

--- a/src/sockets/socket_headers.hpp
+++ b/src/sockets/socket_headers.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdlib>
 #include <cstdint>
 
 #ifdef _WIN32


### PR DESCRIPTION
This is just not possible, since clang with libstdc++ doesn't support std::expected, but with libc++ it doesn't support std::jthread
, this is the peek of C++20 (and C++23)  support 😂  Kappa 🤦🏼‍♂️ 


superseeds #9 

This also cleans up the ci file, to use matrix builds for windows and linux, and not two separate matrix builds, I personally find it better like that (it can be easily made into two builds again)