### PR TITLE
fix: allow compilation on MUSL libc

### DIFF
--- a/src/sockets/socket.cpp
+++ b/src/sockets/socket.cpp
@@ -12,6 +12,12 @@
 #include <string>
 #include <utility>
 
+
+#ifndef _WIN32
+#define IPV6_INFO_PORT(ipv6_info) ((ipv6_info)->sin6_addr.s6_addr)
+#endif
+
+
 namespace c2k {
     [[nodiscard]] static constexpr int to_ai_family(AddressFamily const family) {
         switch (family) {
@@ -241,22 +247,22 @@ namespace c2k {
                 auto const ipv6_info = reinterpret_cast<sockaddr_in6 const*>(&address);
                 auto stream = std::stringstream{};
                 stream << std::hex << std::setfill('0');
-                stream << std::setw(2) << ipv6_info->sin6_addr.__in6_u.__u6_addr8[0] << std::setw(2)
-                       << ipv6_info->sin6_addr.__in6_u.__u6_addr8[1] << ':';
-                stream << std::setw(2) << ipv6_info->sin6_addr.__in6_u.__u6_addr8[2] << std::setw(2)
-                       << ipv6_info->sin6_addr.__in6_u.__u6_addr8[3] << ':';
-                stream << std::setw(2) << ipv6_info->sin6_addr.__in6_u.__u6_addr8[4] << std::setw(2)
-                       << ipv6_info->sin6_addr.__in6_u.__u6_addr8[5] << ':';
-                stream << std::setw(2) << ipv6_info->sin6_addr.__in6_u.__u6_addr8[6] << std::setw(2)
-                       << ipv6_info->sin6_addr.__in6_u.__u6_addr8[7] << ':';
-                stream << std::setw(2) << ipv6_info->sin6_addr.__in6_u.__u6_addr8[8] << std::setw(2)
-                       << ipv6_info->sin6_addr.__in6_u.__u6_addr8[9] << ':';
-                stream << std::setw(2) << ipv6_info->sin6_addr.__in6_u.__u6_addr8[10] << std::setw(2)
-                       << ipv6_info->sin6_addr.__in6_u.__u6_addr8[11] << ':';
-                stream << std::setw(2) << ipv6_info->sin6_addr.__in6_u.__u6_addr8[12] << std::setw(2)
-                       << ipv6_info->sin6_addr.__in6_u.__u6_addr8[13] << ':';
-                stream << std::setw(2) << ipv6_info->sin6_addr.__in6_u.__u6_addr8[14] << std::setw(2)
-                       << ipv6_info->sin6_addr.__in6_u.__u6_addr8[15];
+                stream << std::setw(2) << IPV6_INFO_PORT(ipv6_info)[0] << std::setw(2) << IPV6_INFO_PORT(ipv6_info)[1]
+                       << ':';
+                stream << std::setw(2) << IPV6_INFO_PORT(ipv6_info)[2] << std::setw(2) << IPV6_INFO_PORT(ipv6_info)[3]
+                       << ':';
+                stream << std::setw(2) << IPV6_INFO_PORT(ipv6_info)[4] << std::setw(2) << IPV6_INFO_PORT(ipv6_info)[5]
+                       << ':';
+                stream << std::setw(2) << IPV6_INFO_PORT(ipv6_info)[6] << std::setw(2) << IPV6_INFO_PORT(ipv6_info)[7]
+                       << ':';
+                stream << std::setw(2) << IPV6_INFO_PORT(ipv6_info)[8] << std::setw(2) << IPV6_INFO_PORT(ipv6_info)[9]
+                       << ':';
+                stream << std::setw(2) << IPV6_INFO_PORT(ipv6_info)[10] << std::setw(2) << IPV6_INFO_PORT(ipv6_info)[11]
+                       << ':';
+                stream << std::setw(2) << IPV6_INFO_PORT(ipv6_info)[12] << std::setw(2) << IPV6_INFO_PORT(ipv6_info)[13]
+                       << ':';
+                stream << std::setw(2) << IPV6_INFO_PORT(ipv6_info)[14] << std::setw(2)
+                       << IPV6_INFO_PORT(ipv6_info)[15];
                 return AddressInfo{ AddressFamily::Ipv6,
                                     std::move(stream).str(),
                                     from_network_byte_order(static_cast<std::uint16_t>(ipv6_info->sin6_port)) };


### PR DESCRIPTION
On MUSL libc, the `sockaddr_in6` struct is not the same as on glibc, unfortunately, the inner structure of the struct isn't mandated by POSIX 😓 

Edit: But there is a "public interface", that works on both glibc and musl, thanks to @r00tifant for knowing that 

I needed this for https://github.com/Totto16/oopetris_lobby/commit/6de856d53bc22a825a5991fa0085e8b04df5c5e9 and https://github.com/OpenBrickProtocolFoundation/lobby/pull/5 so that docker image can be built, 

NOTE: after this is merged 🙏🏼  [simulator](https://github.com/OpenBrickProtocolFoundation/simulator) needs to be updated as well, as this is a sub depedendency there and thats the main reason for updating this.
